### PR TITLE
update build logic to not point to specific translation at build time and use old default behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
   cd /tmp && \
   tar -xf resynth.tar.gz && \
   cd resynthesizer-* && \
-  meson setup resynthesizerBuild && \
+  meson setup resynthesizerBuild -Dinstall-translations=false && \
   cd resynthesizerBuild && \
   meson compile --verbose -j $(nproc) && \
   DESTDIR=/buildout meson install && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -21,7 +21,7 @@ RUN \
   cd /tmp && \
   tar -xf resynth.tar.gz && \
   cd resynthesizer-* && \
-  meson setup resynthesizerBuild && \
+  meson setup resynthesizerBuild -Dinstall-translations=false && \
   cd resynthesizerBuild && \
   meson compile --verbose -j $(nproc) && \
   DESTDIR=/buildout meson install && \


### PR DESCRIPTION
They cut a release that enforced linking a system level language at build time for internationalization, need to flag this off for our stack. 